### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ supports tab completions and settings options.
 
 " If option is table type in lua code ,you can use `,` connect each command string eg:
 " find_command,vimgrep_arguments they are both table type. so config it in commandline like
-:Telecope find_files find_command=rg,--ignore,--hidden,--files prompt_prefix=🔍
+:Telescope find_files find_command=rg,--ignore,--hidden,--files prompt_prefix=🔍
 ```
 
 ## Media


### PR DESCRIPTION
👋 
I found this while trying to override the default finder so I can search hidden files in my project.
Would you mind providing an example for `.vimrc`?

I'm quite ignorant of how nvim works to load the file. I tried `lua :Telescope find_files find_command=rg,--ignore,--hidden,--files` but that didn't quite work.